### PR TITLE
Cleaning up CMakeLists to not rely on catkin_make crosstalk

### DIFF
--- a/msl_base/CMakeLists.txt
+++ b/msl_base/CMakeLists.txt
@@ -7,10 +7,6 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 ## Enable exception handling for segfaults
 set(CMAKE_CXX_FLAGS "-rdynamic -g -fnon-call-exceptions -ggdb ${CMAKE_CXX_FLAGS}")
 
-## Used for cgal
-set(CGAL_DONT_OVERRIDE_CMAKE_FLAGS TRUE CACHE BOOL "Don't override flags")
-set(CMAKE_CXX_FLAGS "-lCGAL -lCGAL_Core -frounding-math ${CMAKE_CXX_FLAGS}")
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -27,9 +23,6 @@ find_package(catkin REQUIRED COMPONENTS
   msl_worldmodel
 )
 
-find_package(CGAL REQUIRED COMPONENTS Core)
-
-
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -43,7 +36,6 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES
   CATKIN_DEPENDS alica_engine alica_ros_proxy msl_expressions msl_simulator msl_worldmodel
-  DEPENDS cgal
 )
 
 ###########
@@ -53,15 +45,14 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(include ${catkin_INCLUDE_DIRS} ${CGAL_INCLUDE_DIRS})
-include(${CGAL_USE_FILE})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Declare a cpp executable
 add_executable(msl_base src/Base.cpp)
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(msl_base ${catkin_LIBRARIES} ${CGAL_LIBRARIES})
+target_link_libraries(msl_base ${catkin_LIBRARIES})
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-add_dependencies(msl_base ${catkin_LIBRARIES} ${CGAL_LIBRARIES})
+add_dependencies(msl_base ${catkin_LIBRARIES})

--- a/msl_voronoi_viewer/CMakeLists.txt
+++ b/msl_voronoi_viewer/CMakeLists.txt
@@ -5,13 +5,6 @@
 cmake_minimum_required(VERSION 2.8.0)
 project(msl_voronoi_viewer)
 
-## Use c++ 11x std
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-## Used for cgal
-set(CGAL_DONT_OVERRIDE_CMAKE_FLAGS TRUE CACHE BOOL "Don't override flags")
-set(CMAKE_CXX_FLAGS "-lCGAL -lCGAL_Core -frounding-math ${CMAKE_CXX_FLAGS}")
-
-
 ##############################################################################
 # Catkin
 ##############################################################################
@@ -21,6 +14,10 @@ find_package(catkin REQUIRED COMPONENTS qt_build roscpp message_generation msl_m
 find_package(CGAL REQUIRED COMPONENTS Core)
 include_directories(${catkin_INCLUDE_DIRS} ${CGAL_INCLUDE_DIRS})
 include(${CGAL_USE_FILE})
+
+## Use c++ 11x std
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+
 # Use this to define what the package will export (e.g. libs, headers).
 # Since the default here is to produce only a binary, we don't worry about
 # exporting anything. 

--- a/msl_worldmodel/CMakeLists.txt
+++ b/msl_worldmodel/CMakeLists.txt
@@ -1,21 +1,18 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(msl_worldmodel)
 
-## Use c++ 11x std
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-
-## Enable exception handling for segfaults using SigFault.h
-set(CMAKE_CXX_FLAGS "-rdynamic -fnon-call-exceptions -ggdb ${CMAKE_CXX_FLAGS}")
-
-## Used for cgal
-set(CGAL_DONT_OVERRIDE_CMAKE_FLAGS TRUE CACHE BOOL "Don't override flags")
-set(CMAKE_CXX_FLAGS "-lCGAL -lCGAL_Core -frounding-math ${CMAKE_CXX_FLAGS}")
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED cnc_geometry system_config msl_actuator_msgs msl_sensor_msgs event_handling alica_engine)
 find_package(CGAL REQUIRED COMPONENTS Core)
+ include(${CGAL_USE_FILE})
+
+## Use c++ 11x std
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+
+## Enable exception handling for segfaults using SigFault.h
+set(CMAKE_CXX_FLAGS "-rdynamic -fnon-call-exceptions -ggdb ${CMAKE_CXX_FLAGS}")
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -91,6 +88,7 @@ catkin_package(
   LIBRARIES msl_worldmodel
   CATKIN_DEPENDS cnc_geometry
   DEPENDS cgal
+  CFG_EXTRAS ${PROJECT_NAME}-extras.cmake
 )
 
 ###########
@@ -102,7 +100,6 @@ catkin_package(
 ## Your package locations should be listed before other locations
 
  include_directories(include ${catkin_INCLUDE_DIRS} ${CGAL_INCLUDE_DIRS})
- include(${CGAL_USE_FILE})
 
 ## Declare a cpp library
  add_library(msl_worldmodel

--- a/msl_worldmodel/cmake/msl_worldmodel-extras.cmake
+++ b/msl_worldmodel/cmake/msl_worldmodel-extras.cmake
@@ -1,0 +1,8 @@
+
+## Required for CGAL
+find_package(CGAL REQUIRED COMPONENTS Core)
+include(${CGAL_USE_FILE})
+include_directories(${CGAL_INCLUDE_DIRS})
+
+## Required for this library
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
Fixes https://github.com/catkin/catkin_tools/issues/210

This is the backtrace from master:
```
terminate called after throwing an instance of 'CGAL::Assertion_exception'
  what():  CGAL ERROR: assertion violation!
Expr: -CGAL_IA_MUL(-1.1, 10.1) != CGAL_IA_MUL(1.1, 10.1)
File: /usr/include/CGAL/Interval_nt.h
Line: 209
Explanation: Wrong rounding: did you forget the  -frounding-math  option if you use GCC (or  -fp-model strict  for Intel)?

Program received signal SIGABRT, Aborted.
0x00007ffff5b76cc9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) where
#0  0x00007ffff5b76cc9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007ffff5b7a0d8 in __GI_abort () at abort.c:89
#2  0x00007ffff617b6b5 in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff6179836 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff6179863 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff6179aa2 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007ffff3ac6689 in CGAL::assertion_fail(char const*, char const*, int, char const*) () from /usr/lib/libCGAL.so.10
#7  0x00007ffff696ae2b in CGAL::Interval_nt<false>::Test_runtime_rounding_modes::Test_runtime_rounding_modes (this=0x7ffff6c7b048 <CGAL::Interval_nt<false>::tester>)
    at /usr/include/CGAL/Interval_nt.h:208
#8  0x00007ffff6964e80 in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at /usr/include/CGAL/Interval_nt.h:223
#9  0x00007ffff6965013 in _GLOBAL__sub_I_ConditionCreator.cpp(void) () at /home/jbohren/ws/msl/src/cnc-msl/msl_expressions/autogenerated/src/ConditionCreator.cpp:719
#10 0x00007ffff7dea13a in call_init (l=<optimized out>, argc=argc@entry=1, argv=argv@entry=0x7fffffffcdb8, env=env@entry=0x7fffffffcdc8) at dl-init.c:78
#11 0x00007ffff7dea223 in call_init (env=<optimized out>, argv=<optimized out>, argc=<optimized out>, l=<optimized out>) at dl-init.c:36
#12 _dl_init (main_map=0x7ffff7ffe1c8, argc=1, argv=0x7fffffffcdb8, env=0x7fffffffcdc8) at dl-init.c:126
#13 0x00007ffff7ddb30a in _dl_start_user () from /lib64/ld-linux-x86-64.so.2
#14 0x0000000000000001 in ?? ()
#15 0x00007fffffffd1a7 in ?? ()
#16 0x0000000000000000 in ?? ()
```

This line gives it away:
```
#9  0x00007ffff6965013 in _GLOBAL__sub_I_ConditionCreator.cpp(void) () at /home/jbohren/ws/msl/src/cnc-msl/msl_expressions/autogenerated/src/ConditionCreator.cpp:719
```

The `msl_expressions` package was including the code that was initializing CGAL, but it was relying on `CMAKE_CXX_FLAGS` from one of the other packages. When built in isolation, it wasn't getting the flags it needed. This PR adds a `cfg-extra` which will automatically get all the CGAL stuff when someone depends on `msl_worldmodel`.